### PR TITLE
added avoidKeyboard prop to custom modal

### DIFF
--- a/client/src/components/CustomModal.jsx
+++ b/client/src/components/CustomModal.jsx
@@ -7,6 +7,7 @@ import { theme } from '../../theme';
 const CustomModal = ({ isModalVisible, setModalVisible, children, ...rest }) => {
   return (
     <Modal
+      avoidKeyboard
       animationIn="slideInUp"
       animationOut="slideOutDown"
       backdropTransitionOutTiming={0}


### PR DESCRIPTION
## Description ✍️

The modal package we are using has a feature to increase the height of the modal inputs so the keyboard doesn't cover up the lower inputs when they are selected. This is only a solution to the text in the expense and input forms. For TextInputs outside modals (none are currently being covered up, I think) we can use the built-in React Native `KeyboardAvoidingView` . 

### Changes ⚙️

* Added "avoidKeyboard" prop to Modal component (from 'react-native-modal') 

## Checklist 🗒

- [x] Ran `black .` to format code in `./server`
- [x] Ran `npm run lint:fix` to format code in `./client`
- [x] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #131 