### PR TITLE
b64 img upload

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -8,6 +8,7 @@ from src.routes import (
     login,
     net_worth,
     category,
+    image_to_s3,
 )
 
 # Note: the server runs on http://127.0.0.1:8000
@@ -22,6 +23,7 @@ app.include_router(category_budget.router)
 app.include_router(signup.router)
 app.include_router(login.router)
 app.include_router(category.router)
+app.include_router(image_to_s3.router)
 
 
 @app.get("/")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -15,3 +15,5 @@ bcrypt==3.2.0
 python-jose==3.3.0
 
 requests==2.26.0
+
+google-cloud-storage == 2.1.0

--- a/server/src/routes/image_to_s3.py
+++ b/server/src/routes/image_to_s3.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, HTTPException
+from google.cloud import storage
+from pydantic import BaseModel
+import mimetypes
+import re
+import os
+import base64
+import io
+
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "PATH TO KEYS.JSON"
+
+storage_client = storage.Client()
+my_bucket = storage_client.get_bucket("images-ledgeit")
+
+# endpoint recieves name and base64 encoded image
+class Image_Data(BaseModel):
+    name: str
+    b64Img: str
+
+
+router = APIRouter()
+
+
+@router.post("/upload", response_description="Returns the URL of uploaded image")
+async def upload(data: Image_Data):
+    image = data.b64Img
+    mimeType = re.findall("data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*|$", image)[0]
+    file_name = data.name + mimetypes.guess_extension(mimeType)
+    base64_encoded_image_string = re.sub("^data:image\/\w+;base64,", "", image)
+    decoded_image = base64.b64decode(base64_encoded_image_string)
+    file_to_upload = io.BytesIO(decoded_image)
+
+    file = my_bucket.blob(file_name)
+
+    try:
+        file.upload_from_file(file_to_upload)
+    except:
+        return HTTPException(
+            status_code="404", detail="AN ERROR OCCURRED WHILE UPLOADING"
+        )
+
+    return {"URL": f"https://storage.googleapis.com/images-ledgeit/{file_name}"}


### PR DESCRIPTION
## Description ✍️

Endpoint to upload base64 encoded images to GCP bucket. 

*accidentally closed previous PR 

### Changes ⚙️

* Setup GCP S3 bucket
* Created and tested endpoint `/upload` - takes in name of image (no extension) and the base64 string

## Checklist 🗒

- [x] Ran `black .` to format code in `./server`
- [ ] Ran `npm run lint:fix` to format code in `./client`
- [x] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #121
