### PR TITLE
capture + store images

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,1 @@
-SERVER_URL=http://127.0.0.1:8000
+SERVER_URL=https://ledge-it.herokuapp.com

--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,1 @@
-SERVER_URL=https://ledge-it.herokuapp.com
+SERVER_URL=http://127.0.0.1:8000

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^0.24.0",
         "d3-shape": "^3.1.0",
         "expo": "~42.0.1",
+        "expo-image-picker": "~10.2.2",
         "expo-linear-gradient": "~9.2.0",
         "expo-status-bar": "~1.0.4",
         "query-string": "^7.1.1",
@@ -6858,6 +6859,24 @@
       "dependencies": {
         "expo-modules-core": "~0.2.0",
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-10.2.3.tgz",
+      "integrity": "sha512-8VXLYjclXoQJHbdNLI21rdbnxFisBpZ6TgIifHf9kZ/momFBegUNqEKCjosvxVGVM8f7qaQxJV/znNtW0rDM/w==",
+      "dependencies": {
+        "@expo/config-plugins": "^3.0.0",
+        "expo-modules-core": "~0.2.0",
+        "uuid": "7.0.2"
+      }
+    },
+    "node_modules/expo-image-picker/node_modules/uuid": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -16982,8 +17001,7 @@
         "eslint-plugin-prettier": "3.1.2",
         "eslint-plugin-react": "^7.20.0",
         "eslint-plugin-react-hooks": "^4.0.7",
-        "eslint-plugin-react-native": "^3.10.0",
-        "prettier": "^2.0.2"
+        "eslint-plugin-react-native": "^3.10.0"
       },
       "dependencies": {
         "eslint-plugin-prettier": {
@@ -17040,7 +17058,8 @@
     "@react-navigation/elements": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.1.tgz",
-      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw=="
+      "integrity": "sha512-jIDRJaG8YPIinl4hZXJu/W3TnhDe8hLYmGSEdL1mxZ1aoNMiApCBYkgTy11oq0EfK/koZd3DPSkJNbzBAQmPJw==",
+      "requires": {}
     },
     "@react-navigation/native": {
       "version": "6.0.8",
@@ -17298,7 +17317,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -19532,7 +19552,8 @@
       "version": "22.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz",
       "integrity": "sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-jsx-a11y": {
       "version": "6.4.1",
@@ -19620,7 +19641,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react-native": {
       "version": "3.11.0",
@@ -20093,6 +20115,23 @@
       "requires": {
         "expo-modules-core": "~0.2.0",
         "fontfaceobserver": "^2.1.0"
+      }
+    },
+    "expo-image-picker": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-10.2.3.tgz",
+      "integrity": "sha512-8VXLYjclXoQJHbdNLI21rdbnxFisBpZ6TgIifHf9kZ/momFBegUNqEKCjosvxVGVM8f7qaQxJV/znNtW0rDM/w==",
+      "requires": {
+        "@expo/config-plugins": "^3.0.0",
+        "expo-modules-core": "~0.2.0",
+        "uuid": "7.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+          "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+        }
       }
     },
     "expo-keep-awake": {
@@ -22668,7 +22707,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz",
       "integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
       "requires": {
-        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",
@@ -23706,7 +23744,8 @@
         "ws": {
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+          "requires": {}
         }
       }
     },
@@ -24066,7 +24105,8 @@
     "react-native-dropdown-picker": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/react-native-dropdown-picker/-/react-native-dropdown-picker-5.2.3.tgz",
-      "integrity": "sha512-nT2p/3pzydi6CAUPbC7WR1Yo2/FDX6napouAQ1ueuCGD48afYiWERh2J+mAUes/v4MKl68oriEz9C7GM6aAILg=="
+      "integrity": "sha512-nT2p/3pzydi6CAUPbC7WR1Yo2/FDX6napouAQ1ueuCGD48afYiWERh2J+mAUes/v4MKl68oriEz9C7GM6aAILg==",
+      "requires": {}
     },
     "react-native-gesture-handler": {
       "version": "1.10.3",
@@ -24099,7 +24139,8 @@
     "react-native-iphone-x-helper": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
-      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==",
+      "requires": {}
     },
     "react-native-modal": {
       "version": "13.0.0",
@@ -24150,7 +24191,8 @@
     "react-native-safe-area-context": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz",
-      "integrity": "sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA=="
+      "integrity": "sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==",
+      "requires": {}
     },
     "react-native-svg": {
       "version": "12.1.1",
@@ -24218,7 +24260,8 @@
     "react-native-wheel-scrollview-picker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-wheel-scrollview-picker/-/react-native-wheel-scrollview-picker-2.0.0.tgz",
-      "integrity": "sha512-qJSWBEQyI2gsEx5Gky2Mi072u+tas/HE03xMS3/XeKpFMfkDE7/CaCDdRdvujHlCRMuTQrirMRfOgZEeAi1xXw=="
+      "integrity": "sha512-qJSWBEQyI2gsEx5Gky2Mi072u+tas/HE03xMS3/XeKpFMfkDE7/CaCDdRdvujHlCRMuTQrirMRfOgZEeAi1xXw==",
+      "requires": {}
     },
     "react-refresh": {
       "version": "0.4.3",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.24.0",
     "d3-shape": "^3.1.0",
     "expo": "~42.0.1",
+    "expo-image-picker": "~10.2.2",
     "expo-linear-gradient": "~9.2.0",
     "expo-status-bar": "~1.0.4",
     "query-string": "^7.1.1",

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -7,7 +7,7 @@ import openCamera from '../utils/pickImage';
 export default ({ date, amount, category, name, type, setb64, rounded = false }) => {
   const getImage = async () => {
     const b64img = await openCamera();
-    setb64(`data:image/jpeg;base64,${b64img}`);
+    setb64(b64img);
   };
 
   return (

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import theme from '../../theme';
 import StyledButton from './StyledButton';
+import { openCamera } from '../utils/pickImage.js';
 
-export default ({ date, amount, category, name, type, rounded = false }) => {
+export default ({ date, amount, category, name, type, rounded = false, setb64 }) => {
+  const getImage = async () => {
+    let b64img = await openCamera();
+    setb64(b64img); // not a function??
+  }
   return (
     <View
       style={[styles.box, rounded && { borderBottomRightRadius: 20, borderBottomLeftRadius: 20 }]}>
@@ -14,7 +19,7 @@ export default ({ date, amount, category, name, type, rounded = false }) => {
           iconColor={theme.colors.white}
           iconSize={32}
           customStyles={styles}
-          onTap={() => console.log('camera')}
+          onTap={getImage}
           underlayColor={theme.colors.primary}
         />
       </View>

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -4,11 +4,13 @@ import theme from '../../theme';
 import StyledButton from './StyledButton';
 import { openCamera } from '../utils/pickImage.js';
 
-export default ({ date, amount, category, name, type, rounded = false, setb64 }) => {
+export default ({ date, amount, category, name, type, setb64, rounded = false }) => {
+
   const getImage = async () => {
     let b64img = await openCamera();
-    setb64(b64img); // not a function??
+    setb64(b64img);
   }
+
   return (
     <View
       style={[styles.box, rounded && { borderBottomRightRadius: 20, borderBottomLeftRadius: 20 }]}>

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -8,7 +8,8 @@ export default ({ date, amount, category, name, type, setb64, rounded = false })
 
   const getImage = async () => {
     let b64img = await openCamera();
-    setb64(b64img);
+    setb64('data:image/jpeg;base64,' + b64img);
+    // console.log('data:image/jpeg;base64,' + b64img);
   }
 
   return (

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -2,15 +2,13 @@ import React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import theme from '../../theme';
 import StyledButton from './StyledButton';
-import { openCamera } from '../utils/pickImage.js';
+import openCamera from '../utils/pickImage';
 
 export default ({ date, amount, category, name, type, setb64, rounded = false }) => {
-
   const getImage = async () => {
-    let b64img = await openCamera();
-    setb64('data:image/jpeg;base64,' + b64img);
-    // console.log('data:image/jpeg;base64,' + b64img);
-  }
+    const b64img = await openCamera();
+    setb64(`data:image/jpeg;base64,${b64img}`);
+  };
 
   return (
     <View

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -34,7 +34,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
   const [tag, setTag] = useState(undefined);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
-  const [b64img, setb64img] = useState('');
+  const [base64Image, setBase64Image] = useState('');
 
   const submitExpense = async () => {
     axios
@@ -48,6 +48,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         location,
         category,
         sub_category: tag,
+        ...(base64Image === '' ? {} : {'base64_image': base64Image})
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -63,7 +64,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         category={category}
         amount={Number(price || 0) * -1}
         type="Expense"
-        setb64={(b64) => setb64img(b64)}
+        setb64={setBase64Image}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -34,7 +34,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
   const [tag, setTag] = useState(undefined);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
-  const [b64img, setb64img] = useState(undefined);
+  const [b64img, setb64img] = useState('');
 
   const submitExpense = async () => {
     axios
@@ -63,7 +63,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         category={category}
         amount={Number(price || 0) * -1}
         type="Expense"
-        setb64={setb64img}
+        setb64={(b64) => setb64img(b64)}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Image } from 'react-native';
 import axios from '../providers/axios';
 import AmountBox from '../components/AmountBox';
 import StyledTextInput from '../components/StyledTextInput';
@@ -122,8 +122,12 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         style={{
           flexDirection: 'row',
           justifyContent: 'center',
+          alignItems: 'center',
           marginTop: 20,
         }}>
+        {base64Image !== '' && (
+          <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
+        )} 
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setExpenseModalVisible(false)} />
         </View>

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -34,6 +34,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
   const [tag, setTag] = useState(undefined);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
+  const [b64img, setb64img] = useState(undefined);
 
   const submitExpense = async () => {
     axios
@@ -62,6 +63,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         category={category}
         amount={Number(price || 0) * -1}
         type="Expense"
+        setb64={setb64img}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -48,7 +48,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         location,
         category,
         sub_category: tag,
-        ...(base64Image === '' ? {} : {'base64_image': base64Image})
+        ...(base64Image === '' ? {} : { base64_image: base64Image }),
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -126,8 +126,11 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
           marginTop: 20,
         }}>
         {base64Image !== '' && (
-          <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
-        )} 
+          <Image
+            style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
+            source={{ uri: base64Image }}
+          />
+        )}
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setExpenseModalVisible(false)} />
         </View>

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -31,6 +31,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
+  const [b64img, setb64img] = useState('');
 
   const submitIncome = async () => {
     axios
@@ -52,7 +53,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
 
   return (
     <>
-      <AmountBox date={date} name={name} category={category} amount={amount} type="Income" />
+      <AmountBox date={date} name={name} category={category} amount={amount} type="Income" setb64={setb64img} />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput
         onChange={setAmount}

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -53,7 +53,14 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
 
   return (
     <>
-      <AmountBox date={date} name={name} category={category} amount={amount} type="Income" setb64={setb64img} />
+      <AmountBox 
+        date={date} 
+        name={name} 
+        category={category} 
+        amount={amount} 
+        type="Income" 
+        setb64={(b64) => setb64img(b64)} 
+      />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput
         onChange={setAmount}

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, Image } from 'react-native';
 import axios from '../providers/axios';
 import StyledTextInput from '../components/StyledTextInput';
 import StyledButton from '../components/StyledButton';
@@ -112,8 +112,12 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         style={{
           flexDirection: 'row',
           justifyContent: 'center',
+          alignItems: 'center',
           marginTop: 20,
         }}>
+        {base64Image !== '' && (
+          <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
+        )} 
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setIncomeModalVisible(false)} />
         </View>

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -44,7 +44,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         exchange_rate: 0,
         location,
         category,
-        ...(base64Image === '' ? {} : {'base64_image': base64Image})
+        ...(base64Image === '' ? {} : { base64_image: base64Image }),
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -54,13 +54,13 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
 
   return (
     <>
-      <AmountBox 
-        date={date} 
-        name={name} 
-        category={category} 
-        amount={amount} 
-        type="Income" 
-        setb64={setBase64Image} 
+      <AmountBox
+        date={date}
+        name={name}
+        category={category}
+        amount={amount}
+        type="Income"
+        setb64={setBase64Image}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput
@@ -116,8 +116,11 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
           marginTop: 20,
         }}>
         {base64Image !== '' && (
-          <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
-        )} 
+          <Image
+            style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
+            source={{ uri: base64Image }}
+          />
+        )}
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setIncomeModalVisible(false)} />
         </View>

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -31,7 +31,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
-  const [b64img, setb64img] = useState('');
+  const [base64Image, setBase64Image] = useState('');
 
   const submitIncome = async () => {
     axios
@@ -44,6 +44,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         exchange_rate: 0,
         location,
         category,
+        ...(base64Image === '' ? {} : {'base64_image': base64Image})
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -59,7 +60,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         category={category} 
         amount={amount} 
         type="Income" 
-        setb64={(b64) => setb64img(b64)} 
+        setb64={setBase64Image} 
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -20,6 +20,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
   const [description, setDescription] = useState(item.description);
   const [location, setLocation] = useState(item.location);
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
+  const [b64img, setb64img] = useState('');
 
   const onUpdate = () => {
     axios
@@ -46,6 +47,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
           category={category}
           amount={Number(price || 0) * -1}
           type={type === 'Expenses' ? 'Expense' : 'Income'}
+          setb64={(b64) => setb64img(b64)}
           rounded
         />
         <StyledTextInput

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, Image } from 'react-native';
 import axios from '../providers/axios';
 import StyledButton from '../components/StyledButton';
 import StyledTextInput from '../components/StyledTextInput';
@@ -20,7 +20,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
   const [description, setDescription] = useState(item.description);
   const [location, setLocation] = useState(item.location);
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
-  const [b64img, setb64img] = useState('');
+  const [base64Image, setBase64Image] = useState('');
 
   const onUpdate = () => {
     axios
@@ -31,6 +31,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
         [type === 'Expenses' ? 'price' : 'amount']: price,
         location,
         category,
+        ...(base64Image === '' ? {} : {'base64_image': base64Image})
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -47,7 +48,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
           category={category}
           amount={Number(price || 0) * -1}
           type={type === 'Expenses' ? 'Expense' : 'Income'}
-          setb64={(b64) => setb64img(b64)}
+          setb64={setBase64Image}
           rounded
         />
         <StyledTextInput
@@ -110,6 +111,11 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
           placeholder="Optional..."
           value={location}
         />
+
+        {base64Image !== '' && (
+          <Image style={{width: 100, height: 100, borderWidth: 1, borderColor: 'red'}} source={{uri: base64Image}}/>
+        )} 
+
         <View
           style={{
             flexDirection: 'row',

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -31,7 +31,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
         [type === 'Expenses' ? 'price' : 'amount']: price,
         location,
         category,
-        ...(base64Image === '' ? {} : {'base64_image': base64Image})
+        ...(base64Image === '' ? {} : { base64_image: base64Image }),
       })
       .then(({ data }) => console.log(data))
       .catch((err) => console.log(err));
@@ -120,8 +120,11 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
             marginTop: 20,
           }}>
           {base64Image !== '' && (
-            <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
-          )} 
+            <Image
+              style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
+              source={{ uri: base64Image }}
+            />
+          )}
           <View style={styles.button}>
             <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
           </View>

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -112,16 +112,16 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
           value={location}
         />
 
-        {base64Image !== '' && (
-          <Image style={{width: 100, height: 100, borderWidth: 1, borderColor: 'red'}} source={{uri: base64Image}}/>
-        )} 
-
         <View
           style={{
             flexDirection: 'row',
             justifyContent: 'center',
+            alignItems: 'center',
             marginTop: 20,
           }}>
+          {base64Image !== '' && (
+            <Image style={{width: 85, height: 85, borderRadius: 15, marginHorizontal: 20}} source={{uri: base64Image}}/>
+          )} 
           <View style={styles.button}>
             <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
           </View>

--- a/client/src/utils/pickImage.js
+++ b/client/src/utils/pickImage.js
@@ -1,0 +1,20 @@
+import * as ImagePicker from 'expo-image-picker';
+
+export const openCamera = async () => {
+    const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+
+    if (permissionResult.granted === false) {
+      return;
+    }
+
+    const result = await ImagePicker.launchCameraAsync({
+      base64: true,
+      quality: 1,
+    });
+    
+    if (!result.cancelled) {
+      return result.base64;
+    }
+
+    return null;
+  }

--- a/client/src/utils/pickImage.js
+++ b/client/src/utils/pickImage.js
@@ -16,5 +16,5 @@ export const openCamera = async () => {
       return result.base64;
     }
 
-    return null;
+    return '';
   }

--- a/client/src/utils/pickImage.js
+++ b/client/src/utils/pickImage.js
@@ -1,20 +1,22 @@
 import * as ImagePicker from 'expo-image-picker';
 
-export const openCamera = async () => {
-    const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+const openCamera = async () => {
+  const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
 
-    if (permissionResult.granted === false) {
-      return;
-    }
-
-    const result = await ImagePicker.launchCameraAsync({
-      base64: true,
-      quality: 1,
-    });
-    
-    if (!result.cancelled) {
-      return result.base64;
-    }
-
-    return '';
+  if (permissionResult.granted === false) {
+    return;
   }
+
+  const result = await ImagePicker.launchCameraAsync({
+    base64: true,
+    quality: 1,
+  });
+
+  if (!result.cancelled) {
+    return result.base64;
+  }
+
+  return '';
+};
+
+export default openCamera;

--- a/client/src/utils/pickImage.js
+++ b/client/src/utils/pickImage.js
@@ -13,7 +13,7 @@ const openCamera = async () => {
   });
 
   if (!result.cancelled) {
-    return result.base64;
+    return `data:image/jpeg;base64,${result.base64}`;
   }
 
   return '';

--- a/server/src/models/expense.py
+++ b/server/src/models/expense.py
@@ -16,6 +16,7 @@ class Expense(MongoDBModel):
     location_y: Optional[float] = None
     category: str
     sub_category: Optional[str] = None
+    image_url: Optional[str] = None
 
     @validator("exchange_rate")
     def must_not_be_equal_negative_one(cls, exr):
@@ -36,6 +37,7 @@ class UpdateExpenseModel(MongoDBModel):
     location_y: Optional[float]
     category: Optional[str]
     sub_category: Optional[str]
+    base64_image: Optional[str]
 
     @validator("exchange_rate")
     def must_not_be_equal_negative_one(cls, exr):
@@ -59,3 +61,4 @@ class AddExpense(MongoDBModel):
     location_y: Optional[float] = None
     category: str
     sub_category: Optional[str] = None
+    base64_image: Optional[str] = None

--- a/server/src/models/income.py
+++ b/server/src/models/income.py
@@ -15,6 +15,7 @@ class Income(MongoDBModel):
     location_x: Optional[float] = None
     location_y: Optional[float] = None
     category: Optional[str] = None
+    image_url: Optional[str] = None
 
     @validator("exchange_rate")
     def must_not_be_equal_negative_one(cls, exr):
@@ -34,6 +35,7 @@ class UpdateIncomeModel(MongoDBModel):
     location_x: Optional[float]
     location_y: Optional[float]
     category: Optional[str]
+    base64_image: Optional[str]
 
     @validator("exchange_rate")
     def must_not_be_equal_negative_one(cls, exr):
@@ -56,3 +58,4 @@ class AddIncome(MongoDBModel):
     location_x: Optional[float] = None
     location_y: Optional[float] = None
     category: Optional[str] = None
+    base64_image: Optional[str] = None

--- a/server/src/routes/expense.py
+++ b/server/src/routes/expense.py
@@ -180,7 +180,7 @@ async def update_expense(
             expense["image_url"] = await upload_image(expense["base64_image"])
             del expense["base64_image"]
         except ValueError as err:
-            raise HTTPException(status_code=404, detail=f"{err}")        
+            raise HTTPException(status_code=404, detail=f"{err}")
 
     expense["email"] = current_user["email"]
     expense = jsonable_encoder(expense)
@@ -244,11 +244,11 @@ async def delete_expense(id, current_user: User = Depends(get_current_active_use
     )
 
     if expense_to_delete.image_url is not None:
-        file_name = expense_to_delete.image_url.split('/')[-1]
+        file_name = expense_to_delete.image_url.split("/")[-1]
         try:
             await delete_image(file_name)
         except ValueError as err:
-            raise HTTPException(status_code=404, detail=f"{err}") 
+            raise HTTPException(status_code=404, detail=f"{err}")
 
     delete_result = expense_collection.delete_one(
         {"_id": expense_to_delete["_id"], "email": current_user["email"]}

--- a/server/src/routes/expense.py
+++ b/server/src/routes/expense.py
@@ -102,6 +102,8 @@ def create_expense(
         current_user,
     )
 
+    # TODO: call to upload base64 image if sent to s3 and store the URL
+
     if expense.currency.lower() == "cad":
         expense.exchange_rate = 1
     else:
@@ -157,6 +159,8 @@ def update_expense(
         -price_change,
         current_user,
     )
+
+    # TODO: call to upload base64 image if sent to s3 and store the URL
 
     if expense.currency is not None:
         if expense.currency.lower() == "cad":
@@ -225,6 +229,8 @@ def delete_expense(id, current_user: User = Depends(get_current_active_user)):
         -expense_to_delete["price"],
         current_user,
     )
+
+    # TODO: delete image in bucket?
 
     delete_result = expense_collection.delete_one(
         {"_id": expense_to_delete["_id"], "email": current_user["email"]}

--- a/server/src/routes/expense.py
+++ b/server/src/routes/expense.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from re import compile
 from datetime import date
 
+from ..routes.image_to_s3 import upload_image
 from ..middleware import get_current_active_user
 from ..models.user import User
 from .net_worth import update_net_worth
@@ -74,7 +75,7 @@ def get_expense_by_id(id, current_user: User = Depends(get_current_active_user))
 
 
 @router.post("/expense", response_description="Add new expense", response_model=Expense)
-def create_expense(
+async def create_expense(
     expense: AddExpense = Body(...),
     current_user: User = Depends(get_current_active_user),
 ):
@@ -102,14 +103,20 @@ def create_expense(
         current_user,
     )
 
-    # TODO: call to upload base64 image if sent to s3 and store the URL
-
     if expense.currency.lower() == "cad":
         expense.exchange_rate = 1
     else:
         expense.exchange_rate = get_exchange_rate_to_cad(expense.currency)
 
     expense_dict = {k: v for k, v in expense.dict().items()}
+
+    if "base64_image" in expense:
+        try:
+            expense["image_url"] = await upload_image(expense["base64_image"])
+            del expense["base64_image"]
+        except ValueError as err:
+            raise HTTPException(status_code=404, detail=f"{err}")
+
     expense_dict["email"] = current_user["email"]
 
     try:
@@ -129,7 +136,7 @@ def create_expense(
 @router.put(
     "/expense/{id}", response_description="Update an expense", response_model=Expense
 )
-def update_expense(
+async def update_expense(
     id,
     expense: UpdateExpenseModel = Body(...),
     current_user: User = Depends(get_current_active_user),
@@ -160,8 +167,6 @@ def update_expense(
         current_user,
     )
 
-    # TODO: call to upload base64 image if sent to s3 and store the URL
-
     if expense.currency is not None:
         if expense.currency.lower() == "cad":
             expense.exchange_rate = 1
@@ -169,6 +174,14 @@ def update_expense(
             expense.exchange_rate = get_exchange_rate_to_cad(expense.currency)
 
     expense = {k: v for k, v in expense.dict().items() if v is not None}
+
+    if "base64_image" in expense:
+        try:
+            expense["image_url"] = await upload_image(expense["base64_image"])
+            del expense["base64_image"]
+        except ValueError as err:
+            raise HTTPException(status_code=404, detail=f"{err}")        
+
     expense["email"] = current_user["email"]
     expense = jsonable_encoder(expense)
 

--- a/server/src/routes/image_to_s3.py
+++ b/server/src/routes/image_to_s3.py
@@ -21,7 +21,6 @@ class Image_Data(BaseModel):
     name: str
     b64Img: str
 
-
 router = APIRouter()
 
 @router.post("/upload", response_description="Returns the URL of uploaded image")
@@ -60,4 +59,10 @@ async def upload_image(b64Image: string):
 
     return f"https://storage.googleapis.com/images-ledgeit/{file_name}"
 
-# TODO: Delete file
+
+async def delete_image(file_name: string):
+    blob = my_bucket.blob(file_name)
+    try: 
+        blob.delete()
+    except:
+        raise ValueError("An error occurred while deleting image")

--- a/server/src/routes/image_to_s3.py
+++ b/server/src/routes/image_to_s3.py
@@ -1,3 +1,4 @@
+import string
 from fastapi import APIRouter, HTTPException
 from google.cloud import storage
 from pydantic import BaseModel
@@ -6,10 +7,11 @@ import re
 import os
 import base64
 import io
+import uuid
 
 # TODO: download the "google-keys.json" file from the Google Drive folder and put it in the root of the ./server folder
 #  Then uncomment this line
-# os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "./google-keys.json"
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "./google-keys.json"
 
 storage_client = storage.Client()
 my_bucket = storage_client.get_bucket("images-ledgeit")
@@ -22,7 +24,6 @@ class Image_Data(BaseModel):
 
 router = APIRouter()
 
-
 @router.post("/upload", response_description="Returns the URL of uploaded image")
 async def upload(data: Image_Data):
     image = data.b64Img
@@ -31,7 +32,6 @@ async def upload(data: Image_Data):
     base64_encoded_image_string = re.sub("^data:image\/\w+;base64,", "", image)
     decoded_image = base64.b64decode(base64_encoded_image_string)
     file_to_upload = io.BytesIO(decoded_image)
-
     file = my_bucket.blob(file_name)
 
     try:
@@ -42,3 +42,22 @@ async def upload(data: Image_Data):
         )
 
     return {"URL": f"https://storage.googleapis.com/images-ledgeit/{file_name}"}
+
+
+async def upload_image(b64Image: string):
+    image = b64Image
+    mimeType = re.findall("data:([a-zA-Z0-9]+\/[a-zA-Z0-9-.+]+).*,.*|$", image)[0]
+    file_name = str(uuid.uuid4()) + mimetypes.guess_extension(mimeType)
+    base64_encoded_image_string = re.sub("^data:image\/\w+;base64,", "", image)
+    decoded_image = base64.b64decode(base64_encoded_image_string)
+    file_to_upload = io.BytesIO(decoded_image)
+    file = my_bucket.blob(file_name)
+
+    try:
+        file.upload_from_file(file_to_upload)
+    except:
+        raise ValueError('An error occurred while uploading')
+
+    return f"https://storage.googleapis.com/images-ledgeit/{file_name}"
+
+# TODO: Delete file

--- a/server/src/routes/image_to_s3.py
+++ b/server/src/routes/image_to_s3.py
@@ -11,7 +11,7 @@ import uuid
 
 # TODO: download the "google-keys.json" file from the Google Drive folder and put it in the root of the ./server folder
 #  Then uncomment this line
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "./google-keys.json"
+# os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "./google-keys.json"
 
 storage_client = storage.Client()
 my_bucket = storage_client.get_bucket("images-ledgeit")
@@ -21,7 +21,9 @@ class Image_Data(BaseModel):
     name: str
     b64Img: str
 
+
 router = APIRouter()
+
 
 @router.post("/upload", response_description="Returns the URL of uploaded image")
 async def upload(data: Image_Data):
@@ -55,14 +57,14 @@ async def upload_image(b64Image: string):
     try:
         file.upload_from_file(file_to_upload)
     except:
-        raise ValueError('An error occurred while uploading')
+        raise ValueError("An error occurred while uploading")
 
     return f"https://storage.googleapis.com/images-ledgeit/{file_name}"
 
 
 async def delete_image(file_name: string):
     blob = my_bucket.blob(file_name)
-    try: 
+    try:
         blob.delete()
     except:
         raise ValueError("An error occurred while deleting image")

--- a/server/src/routes/income.py
+++ b/server/src/routes/income.py
@@ -68,7 +68,7 @@ async def create_income(
         income.exchange_rate = get_exchange_rate_to_cad(income.currency)
 
     income_dict = {k: v for k, v in income.dict().items()}
-    
+
     if "base64_image" in income_dict:
         try:
             income_dict["image_url"] = await upload_image(income_dict["base64_image"])
@@ -160,7 +160,9 @@ async def update_income(
 @router.delete(
     "/income/{id}", response_description="Delete income by id", response_model=Income
 )
-async def delete_income_by_id(id, current_user: User = Depends(get_current_active_user)):
+async def delete_income_by_id(
+    id, current_user: User = Depends(get_current_active_user)
+):
     income_to_delete: Income = income_collection.find_one(
         {"_id": id, "email": current_user["email"]}
     )
@@ -186,11 +188,11 @@ async def delete_income_by_id(id, current_user: User = Depends(get_current_activ
     )
 
     if income_to_delete.image_url is not None:
-        file_name = income_to_delete.image_url.split('/')[-1]
+        file_name = income_to_delete.image_url.split("/")[-1]
         try:
             await delete_image(file_name)
         except ValueError as err:
-            raise HTTPException(status_code=404, detail=f"{err}") 
+            raise HTTPException(status_code=404, detail=f"{err}")
 
     if delete_result.deleted_count == 1:
         return JSONResponse(

--- a/server/src/routes/income.py
+++ b/server/src/routes/income.py
@@ -66,6 +66,8 @@ def create_income(
     else:
         income.exchange_rate = get_exchange_rate_to_cad(income.currency)
 
+    # TODO: call to upload base64 image if sent to s3 and store the URL
+
     income_dict = {k: v for k, v in income.dict().items()}
     income_dict["email"] = current_user["email"]
 
@@ -106,6 +108,8 @@ def update_income(
     update_net_worth(
         net_worth_to_update["_id"], amount_change, income.date, False, current_user
     )
+
+    # TODO: call to upload base64 image if sent to s3 and store the URL
 
     if income.currency is not None:
         if income.currency.lower() == "cad":
@@ -167,6 +171,8 @@ def delete_income_by_id(id, current_user: User = Depends(get_current_active_user
     delete_result = income_collection.delete_one(
         {"_id": id, "email": current_user["email"]}
     )
+
+    # TODO: delete image?
 
     if delete_result.deleted_count == 1:
         return JSONResponse(


### PR DESCRIPTION
## Description ✍️

Allow user to capture images of receipts/income slips and store on BE

### Changes ⚙️

* Used `expo-image-picker` to allow to user to take images
* Updated income/expense models to hold `image_url`
* Updated add/edit income/expense models to hold `base64_image` 
* CRUD income/expense endpoints edited to update stored image

## Checklist 🗒

- [x] Ran `black .` to format code in `./server`
- [x] Ran `npm run lint:fix` to format code in `./client`
- [ ] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #157 
