### PR TITLE
Homepage Graph

### DIFF
--- a/client/src/components/HomePage/StaticAreaGraph.jsx
+++ b/client/src/components/HomePage/StaticAreaGraph.jsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, StyleSheet, Dimensions } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import axios from "../../providers/axios";
+import theme from '../../../theme';
+import { VictoryChart, VictoryArea, VictoryAxis } from 'victory-native';
+import {Defs, LinearGradient, Stop} from "react-native-svg";
+
+const URL = process.env.SERVER_URL;
+
+const StaticAreaGraph = ({ }) => {
+  const today = new Date();
+  const todayString = today.toISOString().split('T')[0];
+  const lowerBound = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
+  const lowerBoundString = lowerBound.toISOString().split('T')[0];
+  const [databaseExpense, setDatabaseExpense] = useState([]);
+  const [compressedData, setCompressedData] = useState([]); 
+
+  const handleProcessingData = (data) => {
+    if (data === undefined || data === null || data.length < 1) {
+      setCompressedData([]);
+      return;
+    }
+
+    let selectedData = data.map((obj) => {
+        return {
+          x: obj.date,
+          y: obj.price,
+        };
+    });
+
+    // Make sure there is only one entry for each date.
+    // If there are more than one entry with the same date, compress them into one entry
+    let temp = [];
+    selectedData.forEach((row) => {
+      if (temp.length <= 0) {
+        temp.push(row);
+      } else {
+        const previous = temp.pop();
+        if (previous.x === row.x) {
+          previous.y += row.y;
+          temp.push(previous);
+        } else {
+          temp.push(previous);
+          temp.push(row);
+        }
+      }
+    });
+    
+    temp = temp.map((obj) => {
+        return {
+            x: new Date(obj.x).getTime(),
+            y: obj.y.toFixed(2),
+        };
+    });
+
+    setCompressedData(temp);
+    console.log(temp)
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      axios
+        .get(`${URL}/expense/ranged/${lowerBoundString}/${todayString}`)
+        .then(({ data }) => setDatabaseExpense(data.reverse()))
+        .catch((err) => console.log(err));
+    }, []),
+  );
+
+useEffect(() => {
+    handleProcessingData(databaseExpense);
+}, [databaseExpense])
+
+  return (
+    <View style={styles.container} >
+      <View>
+       <VictoryChart
+          width= {Dimensions.get('window').width /0.93}
+          height = { Dimensions.get('window').height / 3}
+          style={{
+            parent: {
+              width: '100%',
+              height: 'auto',
+              marginTop: -30,
+              marginLeft: -40,
+              marginBottom: -70,
+              paddingRight: 30,
+              overflow: 'visible',
+            },
+            data: {
+              overflow: 'visible',
+            }
+          }}
+        >
+          <Defs>
+            <LinearGradient id='gradientFill'
+              x1="0%" y1="0%" x2="0%" y2="100%"
+            >
+              <Stop stopColor="white" offset="20%" stopOpacity="0.9" />
+              <Stop stopColor= {theme.colors.primary} offset="100%" stopOpacity="1" />
+            </LinearGradient>
+          </Defs>
+          <VictoryArea
+            style={{
+              data: {
+                fill: 'url(#gradientFill)',
+                stroke: theme.colors.primaryDark,
+                strokeWidth: 3,
+              },
+            }}
+            interpolation='catmullRom'
+
+            data={compressedData}
+          />
+          <VictoryAxis style={{ 
+              axis: {stroke: "transparent"}, 
+              ticks: {stroke: "transparent"},
+              tickLabels: { fill:"transparent"} 
+          }} />
+        </VictoryChart>
+      </View>
+    </View>
+  );
+};
+
+export default StaticAreaGraph;
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    overflow: 'scroll',
+    paddingHorizontal: 5
+    // flexGrow: 1,
+  }
+});
+
+

--- a/client/src/components/HomePage/StaticAreaGraph.jsx
+++ b/client/src/components/HomePage/StaticAreaGraph.jsx
@@ -1,20 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
-import axios from "../../providers/axios";
-import theme from '../../../theme';
 import { VictoryChart, VictoryArea, VictoryAxis } from 'victory-native';
-import {Defs, LinearGradient, Stop} from "react-native-svg";
+import { Defs, LinearGradient, Stop } from 'react-native-svg';
+import axios from '../../providers/axios';
+import theme from '../../../theme';
 
 const URL = process.env.SERVER_URL;
 
-const StaticAreaGraph = ({ }) => {
+const StaticAreaGraph = () => {
   const today = new Date();
   const todayString = today.toISOString().split('T')[0];
   const lowerBound = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 7);
   const lowerBoundString = lowerBound.toISOString().split('T')[0];
   const [databaseExpense, setDatabaseExpense] = useState([]);
-  const [compressedData, setCompressedData] = useState([]); 
+  const [compressedData, setCompressedData] = useState([]);
 
   const handleProcessingData = (data) => {
     if (data === undefined || data === null || data.length < 1) {
@@ -22,11 +22,11 @@ const StaticAreaGraph = ({ }) => {
       return;
     }
 
-    let selectedData = data.map((obj) => {
-        return {
-          x: obj.date,
-          y: obj.price,
-        };
+    const selectedData = data.map((obj) => {
+      return {
+        x: obj.date,
+        y: obj.price,
+      };
     });
 
     // Make sure there is only one entry for each date.
@@ -46,16 +46,16 @@ const StaticAreaGraph = ({ }) => {
         }
       }
     });
-    
+
     temp = temp.map((obj) => {
-        return {
-            x: new Date(obj.x).getTime(),
-            y: obj.y.toFixed(2),
-        };
+      return {
+        x: new Date(obj.x).getTime(),
+        y: obj.y.toFixed(2),
+      };
     });
 
     setCompressedData(temp);
-    console.log(temp)
+    console.log(temp);
   };
 
   useFocusEffect(
@@ -64,19 +64,19 @@ const StaticAreaGraph = ({ }) => {
         .get(`${URL}/expense/ranged/${lowerBoundString}/${todayString}`)
         .then(({ data }) => setDatabaseExpense(data.reverse()))
         .catch((err) => console.log(err));
-    }, []),
+    }, [lowerBoundString, todayString]),
   );
 
-useEffect(() => {
+  useEffect(() => {
     handleProcessingData(databaseExpense);
-}, [databaseExpense])
+  }, [databaseExpense]);
 
   return (
-    <View style={styles.container} >
+    <View style={styles.container}>
       <View>
-       <VictoryChart
-          width= {Dimensions.get('window').width /0.93}
-          height = { Dimensions.get('window').height / 3}
+        <VictoryChart
+          width={Dimensions.get('window').width / 0.93}
+          height={Dimensions.get('window').height / 3}
           style={{
             parent: {
               width: '100%',
@@ -89,15 +89,12 @@ useEffect(() => {
             },
             data: {
               overflow: 'visible',
-            }
-          }}
-        >
+            },
+          }}>
           <Defs>
-            <LinearGradient id='gradientFill'
-              x1="0%" y1="0%" x2="0%" y2="100%"
-            >
+            <LinearGradient id="gradientFill" x1="0%" y1="0%" x2="0%" y2="100%">
               <Stop stopColor="white" offset="20%" stopOpacity="0.9" />
-              <Stop stopColor= {theme.colors.primary} offset="100%" stopOpacity="1" />
+              <Stop stopColor={theme.colors.primary} offset="100%" stopOpacity="1" />
             </LinearGradient>
           </Defs>
           <VictoryArea
@@ -108,15 +105,16 @@ useEffect(() => {
                 strokeWidth: 3,
               },
             }}
-            interpolation='catmullRom'
-
+            interpolation="catmullRom"
             data={compressedData}
           />
-          <VictoryAxis style={{ 
-              axis: {stroke: "transparent"}, 
-              ticks: {stroke: "transparent"},
-              tickLabels: { fill:"transparent"} 
-          }} />
+          <VictoryAxis
+            style={{
+              axis: { stroke: 'transparent' },
+              ticks: { stroke: 'transparent' },
+              tickLabels: { fill: 'transparent' },
+            }}
+          />
         </VictoryChart>
       </View>
     </View>
@@ -129,9 +127,7 @@ const styles = StyleSheet.create({
   container: {
     display: 'flex',
     overflow: 'scroll',
-    paddingHorizontal: 5
+    paddingHorizontal: 5,
     // flexGrow: 1,
-  }
+  },
 });
-
-

--- a/client/src/components/HomePage/ToggleCard.jsx
+++ b/client/src/components/HomePage/ToggleCard.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useRef } from 'react';
 import { StyleSheet, View, Text, FlatList, Dimensions, Animated } from 'react-native';
+import StaticAreaGraph from './StaticAreaGraph';
 import Paginator from './Paginator';
 import theme from '../../../theme';
+import StyledButton from '../StyledButton';
 
 const data = [
   {
@@ -12,7 +14,7 @@ const data = [
   {
     id: '2',
     title: 'Calendar',
-    description: 'This is a calendar',
+    description: 'Here lies the calendar',
   },
 ];
 
@@ -26,6 +28,28 @@ const ToggleCard = () => {
   }).current;
 
   const viewConfig = useRef({ viewAreaCoveragePercentThreshold: 50 }).current;
+
+  const renderItemCard = (item) => {
+    return (
+      <View style={styles.container}>
+        <View style={styles.content}>
+          {item.title === "Visualization" ? 
+          <>
+            <StyledButton
+                key="all"
+                label="Last 7 Days"
+                customStyles={buttonSelectedStyle}
+                />
+            <StaticAreaGraph scrollX = {scrollX}/>
+          </>
+          : null}
+          {item.title === "Calendar" ?
+          <Text style={styles.text}>{item.description}</Text>
+          : null}
+        </View>
+      </View>
+    );
+  };
 
   return (
     <View style={styles.container}>
@@ -48,22 +72,14 @@ const ToggleCard = () => {
       <Paginator data={data} scrollX={scrollX} />
     </View>
   );
+  
 };
 
-const renderItemCard = (item) => {
-  return (
-    <View style={styles.container}>
-      <View style={styles.content}>
-        <Text style={styles.text}>{item.description}</Text>
-      </View>
-    </View>
-  );
-};
 
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    height: 320,
+    height: 360,
     justifyContent: 'center',
     alignItems: 'center',
     width: Dimensions.get('window').width,
@@ -79,21 +95,46 @@ const styles = StyleSheet.create({
 
   content: {
     display: 'flex',
-    height: 230,
+    height: 270,
     width: Dimensions.get('window').width - 30,
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 4,
     borderRadius: 20,
-    backgroundColor: theme.colors.primary,
+    backgroundColor: 'white',
     borderColor: theme.colors.primaryDark,
+    // paddingTop: 10 
   },
 
   text: {
     fontWeight: 'bold',
-    color: theme.colors.white,
+    color: theme.colors.black,
     fontSize: 20,
   },
 });
+
+const buttonSelectedStyle = StyleSheet.create({
+  background: {
+    backgroundColor: theme.colors.primary,
+    padding: 6,
+    display: 'flex',
+    // margin: 5,
+    marginTop: 5,
+    paddingHorizontal: 10,
+    // width: 100,
+    alignItems: 'center',
+    borderRadius: 20,
+    shadowRadius: 5,
+    shadowOpacity: 0.2,
+    shadowOffset: { width: 0, height: 0 },
+    borderColor: theme.colors.primary,
+    borderWidth: 3,
+  },
+  text: {
+    color: theme.colors.textLight,
+    fontWeight: 'bold',
+  },
+  highlightStyle: {},
+}); 
 
 export default ToggleCard;

--- a/client/src/components/HomePage/ToggleCard.jsx
+++ b/client/src/components/HomePage/ToggleCard.jsx
@@ -33,19 +33,13 @@ const ToggleCard = () => {
     return (
       <View style={styles.container}>
         <View style={styles.content}>
-          {item.title === "Visualization" ? 
-          <>
-            <StyledButton
-                key="all"
-                label="Last 7 Days"
-                customStyles={buttonSelectedStyle}
-                />
-            <StaticAreaGraph scrollX = {scrollX}/>
-          </>
-          : null}
-          {item.title === "Calendar" ?
-          <Text style={styles.text}>{item.description}</Text>
-          : null}
+          {item.title === 'Visualization' ? (
+            <>
+              <StyledButton key="all" label="Last 7 Days" customStyles={buttonSelectedStyle} />
+              <StaticAreaGraph scrollX={scrollX} />
+            </>
+          ) : null}
+          {item.title === 'Calendar' ? <Text style={styles.text}>{item.description}</Text> : null}
         </View>
       </View>
     );
@@ -72,9 +66,7 @@ const ToggleCard = () => {
       <Paginator data={data} scrollX={scrollX} />
     </View>
   );
-  
 };
-
 
 const styles = StyleSheet.create({
   container: {
@@ -103,7 +95,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     backgroundColor: 'white',
     borderColor: theme.colors.primaryDark,
-    // paddingTop: 10 
+    // paddingTop: 10
   },
 
   text: {
@@ -135,6 +127,6 @@ const buttonSelectedStyle = StyleSheet.create({
     fontWeight: 'bold',
   },
   highlightStyle: {},
-}); 
+});
 
 export default ToggleCard;

--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -1,10 +1,6 @@
 export const formatString = (str) => str.trim().toLowerCase();
 
-export const formatNumber = (num, digits = 2) =>
-  Math.abs(num).toLocaleString(undefined, {
-    minimumFractionDigits: digits,
-    maximumFractionDigits: digits,
-  });
+export const formatNumber = (num, digits = 2) => Math.abs(num).toFixed(digits);
 
 /**
  * "30/12/2021" -> "2021-12-30"


### PR DESCRIPTION
## Description ✍️

Implemented small graph on the home page based on last 7 days expense.

### Changes ⚙️

* Changed toggle card implementation to render the static graph when the graph tab is selected.
* Implemented static area graph (couldn't use the same library as the analytics page as it caused issues with toggling between graph and calendar tabs)

## Checklist 🗒

- [ ] Ran `black .` to format code in `./server`
- [X] Ran `npm run lint:fix` to format code in `./client`
- [X] Assigned PR to all authors
- [X] Requested at least one reviewer
- [X] Linked the PR to its respective issue in ZenHub
- [X] Replaced the X below with the issue number

Closes #162 
