### PR TITLE
img preview modal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,9 +30,10 @@
         "react-native-paper": "^4.9.2",
         "react-native-reanimated": "~2.2.0",
         "react-native-svg": "12.1.1",
+        "react-native-switch-selector": "^2.2.0",
         "react-native-tailwindcss": "^1.1.11",
         "react-native-web": "^0.17.5",
-        "react-native-webview": "^11.17.1",
+        "react-native-webview": "11.6.2",
         "react-native-wheel-scrollview-picker": "^2.0.0",
         "victory-native": "^36.2.1"
       },
@@ -11642,6 +11643,14 @@
         "react-native": ">=0.50.0"
       }
     },
+    "node_modules/react-native-switch-selector": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-switch-selector/-/react-native-switch-selector-2.2.0.tgz",
+      "integrity": "sha512-dbw5rOJqJIuhlzzmGCav1zeoidNVf5ES2jZtXltKItHdbx+SeXBOvRFLy7xbl2fg9pT121HMQ8lzx6qXyrrLEw==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "node_modules/react-native-tailwindcss": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/react-native-tailwindcss/-/react-native-tailwindcss-1.1.11.tgz",
@@ -11689,16 +11698,15 @@
       }
     },
     "node_modules/react-native-webview": {
-      "version": "11.17.2",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.17.2.tgz",
-      "integrity": "sha512-7Sac02xq11qFACJmSUuCnH0aUFtSWUvSRC09EZ2qwNXq4IvT05xlX6978nlKUXf2ljw/0qZIzqbKzuXnu6Wq8Q==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.2.tgz",
+      "integrity": "sha512-7e5ltLBgqt1mX0gdTTS2nFPIjfS6y300wqJ4rLWqU71lDO+8ZeayfsF5qo83qxo2Go74CtLnSeWae4pdGwUqYw==",
       "dependencies": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+        "react-native": ">=0.60 <=0.64"
       }
     },
     "node_modules/react-native-webview/node_modules/escape-string-regexp": {
@@ -17001,8 +17009,7 @@
         "eslint-plugin-prettier": "3.1.2",
         "eslint-plugin-react": "^7.20.0",
         "eslint-plugin-react-hooks": "^4.0.7",
-        "eslint-plugin-react-native": "^3.10.0",
-        "prettier": "^2.0.2"
+        "eslint-plugin-react-native": "^3.10.0"
       },
       "dependencies": {
         "eslint-plugin-prettier": {
@@ -22708,7 +22715,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.59.0.tgz",
       "integrity": "sha512-1O3wrnMq4NcPQ1asEcl9lRDn/t+F1Oef6S9WaYVIKEhg9m/EQRGVrrTVP+R6B5Eeaj3+zNKbzM8Dx/NWy1hUbQ==",
       "requires": {
-        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.59.0",
         "metro-react-native-babel-preset": "0.59.0",
@@ -24205,6 +24211,14 @@
         "css-tree": "^1.0.0-alpha.39"
       }
     },
+    "react-native-switch-selector": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-switch-selector/-/react-native-switch-selector-2.2.0.tgz",
+      "integrity": "sha512-dbw5rOJqJIuhlzzmGCav1zeoidNVf5ES2jZtXltKItHdbx+SeXBOvRFLy7xbl2fg9pT121HMQ8lzx6qXyrrLEw==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-tailwindcss": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/react-native-tailwindcss/-/react-native-tailwindcss-1.1.11.tgz",
@@ -24244,9 +24258,9 @@
       }
     },
     "react-native-webview": {
-      "version": "11.17.2",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.17.2.tgz",
-      "integrity": "sha512-7Sac02xq11qFACJmSUuCnH0aUFtSWUvSRC09EZ2qwNXq4IvT05xlX6978nlKUXf2ljw/0qZIzqbKzuXnu6Wq8Q==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.6.2.tgz",
+      "integrity": "sha512-7e5ltLBgqt1mX0gdTTS2nFPIjfS6y300wqJ4rLWqU71lDO+8ZeayfsF5qo83qxo2Go74CtLnSeWae4pdGwUqYw==",
       "requires": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -4,10 +4,16 @@ import theme from '../../theme';
 import StyledButton from './StyledButton';
 import openCamera from '../utils/pickImage';
 
-export default ({ date, amount, category, name, type, setb64, rounded = false }) => {
+export default ({ date, amount, category, name, type, currb64img, setb64, setImgModal, rounded = false }) => {
   const getImage = async () => {
-    const b64img = await openCamera();
-    setb64(b64img);
+    
+    if (currb64img == '') {
+      const b64img = await openCamera();
+      setb64(b64img);
+    }
+
+    setImgModal(true);
+
   };
 
   return (

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -9,6 +9,7 @@ export default ({ date, amount, category, name, type, currb64img, setb64, setImg
     
     if (currb64img == '') {
       const b64img = await openCamera();
+      if (b64img == '') return; 
       setb64(b64img);
     }
 

--- a/client/src/components/AmountBox.jsx
+++ b/client/src/components/AmountBox.jsx
@@ -4,17 +4,25 @@ import theme from '../../theme';
 import StyledButton from './StyledButton';
 import openCamera from '../utils/pickImage';
 
-export default ({ date, amount, category, name, type, currb64img, setb64, setImgModal, rounded = false }) => {
+export default ({
+  date,
+  amount,
+  category,
+  name,
+  type,
+  currb64img,
+  setb64,
+  setImgModal,
+  rounded = false,
+}) => {
   const getImage = async () => {
-    
     if (currb64img == '') {
       const b64img = await openCamera();
-      if (b64img == '') return; 
+      if (b64img == '') return;
       setb64(b64img);
     }
 
     setImgModal(true);
-
   };
 
   return (

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -6,6 +6,7 @@ import StyledTextInput from '../components/StyledTextInput';
 import StyledButton from '../components/StyledButton';
 import StyledSelect from '../components/StyledSelect';
 import { formatDateBE } from '../utils/formatters';
+import ImagePreview from './ImagePreview';
 import ToggleButtons from '../components/ToggleButtons';
 
 const URL = process.env.SERVER_URL;
@@ -34,6 +35,7 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
   const [tag, setTag] = useState(undefined);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
+  const [imagePreviewVisible, setImagePreviewVisible] = useState(false);
   const [base64Image, setBase64Image] = useState('');
 
   const submitExpense = async () => {
@@ -64,7 +66,9 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
         category={category}
         amount={Number(price || 0) * -1}
         type="Expense"
+        currb64img={base64Image}
         setb64={setBase64Image}
+        setImgModal={setImagePreviewVisible}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput
@@ -125,19 +129,23 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
           alignItems: 'center',
           marginTop: 20,
         }}>
-        {base64Image !== '' && (
-          <Image
-            style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
-            source={{ uri: base64Image }}
-          />
-        )}
+    
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setExpenseModalVisible(false)} />
         </View>
+    
         <View style={styles.button}>
           <StyledButton label="Add" onTap={submitExpense} />
         </View>
+    
       </View>
+
+      <ImagePreview 
+        isModalVisible={imagePreviewVisible} 
+        setModalVisible={setImagePreviewVisible} 
+        b64Img={base64Image}
+        setb64img={setBase64Image}
+      />
     </>
   );
 };

--- a/client/src/modals/ExpenseForm.jsx
+++ b/client/src/modals/ExpenseForm.jsx
@@ -129,20 +129,18 @@ const AddExpense = ({ setModalVisible, setExpenseModalVisible, type, setType }) 
           alignItems: 'center',
           marginTop: 20,
         }}>
-    
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setExpenseModalVisible(false)} />
         </View>
-    
+
         <View style={styles.button}>
           <StyledButton label="Add" onTap={submitExpense} />
         </View>
-    
       </View>
 
-      <ImagePreview 
-        isModalVisible={imagePreviewVisible} 
-        setModalVisible={setImagePreviewVisible} 
+      <ImagePreview
+        isModalVisible={imagePreviewVisible}
+        setModalVisible={setImagePreviewVisible}
         b64Img={base64Image}
         setb64img={setBase64Image}
       />

--- a/client/src/modals/ImagePreview.jsx
+++ b/client/src/modals/ImagePreview.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, StyleSheet, Image } from 'react-native';
+import CustomModal from "../components/CustomModal";
+import StyledButton from '../components/StyledButton';
+
+
+const ImagePreview = ({ isModalVisible, setModalVisible, b64Img, setb64img }) => {
+    const deleteAndClose = () => {
+        setModalVisible(false);
+        setb64img('');
+    }
+
+    return (
+        <CustomModal isModalVisible={isModalVisible} setModalVisible={setModalVisible}>
+            {b64Img !== '' &&
+                <Image
+                style={{ width: 320, height: 500, borderRadius: 15, marginHorizontal: 20 }}
+                source={{ uri: b64Img }}
+                />
+            }
+
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'center',
+            alignItems: 'center',
+            marginTop: 20,
+        }}>
+
+          <View style={styles.button}>
+            <StyledButton label="Save" onTap={() => setModalVisible(false)} />
+          </View>
+          
+          <View style={styles.button}>
+            <StyledButton label="Delete" onTap={() => deleteAndClose()} />
+          </View>
+          
+        </View>
+
+        </CustomModal>
+    )
+}
+
+const styles = StyleSheet.create({
+   button: {
+       marginHorizontal: 20,
+   } 
+})
+
+export default ImagePreview;

--- a/client/src/modals/ImagePreview.jsx
+++ b/client/src/modals/ImagePreview.jsx
@@ -1,50 +1,46 @@
 import React from 'react';
 import { View, StyleSheet, Image } from 'react-native';
-import CustomModal from "../components/CustomModal";
+import CustomModal from '../components/CustomModal';
 import StyledButton from '../components/StyledButton';
 
-
 const ImagePreview = ({ isModalVisible, setModalVisible, b64Img, setb64img }) => {
-    const deleteAndClose = () => {
-        setModalVisible(false);
-        setb64img('');
-    }
+  const deleteAndClose = () => {
+    setModalVisible(false);
+    setb64img('');
+  };
 
-    return (
-        <CustomModal isModalVisible={isModalVisible} setModalVisible={setModalVisible}>
-            {b64Img !== '' &&
-                <Image
-                style={{ width: 320, height: 500, borderRadius: 15, marginHorizontal: 20 }}
-                source={{ uri: b64Img }}
-                />
-            }
+  return (
+    <CustomModal isModalVisible={isModalVisible} setModalVisible={setModalVisible}>
+      {b64Img !== '' && (
+        <Image
+          style={{ width: 320, height: 500, borderRadius: 15, marginHorizontal: 20 }}
+          source={{ uri: b64Img }}
+        />
+      )}
 
-        <View
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginTop: 20,
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginTop: 20,
         }}>
-
-          <View style={styles.button}>
-            <StyledButton label="Save" onTap={() => setModalVisible(false)} />
-          </View>
-          
-          <View style={styles.button}>
-            <StyledButton label="Delete" onTap={() => deleteAndClose()} />
-          </View>
-          
+        <View style={styles.button}>
+          <StyledButton label="Save" onTap={() => setModalVisible(false)} />
         </View>
 
-        </CustomModal>
-    )
-}
+        <View style={styles.button}>
+          <StyledButton label="Delete" onTap={() => deleteAndClose()} />
+        </View>
+      </View>
+    </CustomModal>
+  );
+};
 
 const styles = StyleSheet.create({
-   button: {
-       marginHorizontal: 20,
-   } 
-})
+  button: {
+    marginHorizontal: 20,
+  },
+});
 
 export default ImagePreview;

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -6,6 +6,7 @@ import StyledButton from '../components/StyledButton';
 import StyledSelect from '../components/StyledSelect';
 import { formatDateBE } from '../utils/formatters';
 import AmountBox from '../components/AmountBox';
+import ImagePreview from './ImagePreview';
 import ToggleButtons from '../components/ToggleButtons';
 
 const URL = process.env.SERVER_URL;
@@ -31,6 +32,7 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
   const [description, setDesc] = useState(undefined);
   const [location, setLocation] = useState(undefined);
+  const [imagePreviewVisible, setImagePreviewVisible] = useState(false);
   const [base64Image, setBase64Image] = useState('');
 
   const submitIncome = async () => {
@@ -60,7 +62,9 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         category={category}
         amount={amount}
         type="Income"
+        currb64img={base64Image}
         setb64={setBase64Image}
+        setImgModal={setImagePreviewVisible}
       />
       <ToggleButtons type={type} setType={setType} />
       <StyledTextInput
@@ -115,19 +119,24 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
           alignItems: 'center',
           marginTop: 20,
         }}>
-        {base64Image !== '' && (
-          <Image
-            style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
-            source={{ uri: base64Image }}
-          />
-        )}
+
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setIncomeModalVisible(false)} />
         </View>
+
         <View style={styles.button}>
           <StyledButton label="Add" onTap={submitIncome} />
         </View>
+
       </View>
+
+      <ImagePreview 
+        isModalVisible={imagePreviewVisible} 
+        setModalVisible={setImagePreviewVisible} 
+        b64Img={base64Image}
+        setb64img={setBase64Image}
+      />
+      
     </>
   );
 };

--- a/client/src/modals/IncomeForm.jsx
+++ b/client/src/modals/IncomeForm.jsx
@@ -119,7 +119,6 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
           alignItems: 'center',
           marginTop: 20,
         }}>
-
         <View style={styles.button}>
           <StyledButton label="Cancel" onTap={() => setIncomeModalVisible(false)} />
         </View>
@@ -127,16 +126,14 @@ const AddIncome = ({ setModalVisible, setIncomeModalVisible, type, setType }) =>
         <View style={styles.button}>
           <StyledButton label="Add" onTap={submitIncome} />
         </View>
-
       </View>
 
-      <ImagePreview 
-        isModalVisible={imagePreviewVisible} 
-        setModalVisible={setImagePreviewVisible} 
+      <ImagePreview
+        isModalVisible={imagePreviewVisible}
+        setModalVisible={setImagePreviewVisible}
         b64Img={base64Image}
         setb64img={setBase64Image}
       />
-      
     </>
   );
 };

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -6,6 +6,7 @@ import StyledTextInput from '../components/StyledTextInput';
 import StyledSelect from '../components/StyledSelect';
 import CustomModal from '../components/CustomModal';
 import AmountBox from '../components/AmountBox';
+import ImagePreview from './ImagePreview';
 import theme from '../../theme';
 import { formatDateBE, formatDateFE } from '../utils/formatters';
 
@@ -20,6 +21,7 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
   const [description, setDescription] = useState(item.description);
   const [location, setLocation] = useState(item.location);
   const [categoryDropdownVisible, setCategoryDropdownVisible] = useState(false);
+  const [imagePreviewVisible, setImagePreviewVisible] = useState(false);
   const [base64Image, setBase64Image] = useState('');
 
   const onUpdate = () => {
@@ -48,7 +50,9 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
           category={category}
           amount={Number(price || 0) * -1}
           type={type === 'Expenses' ? 'Expense' : 'Income'}
+          currb64img={base64Image}
           setb64={setBase64Image}
+          setImgModal={setImagePreviewVisible}
           rounded
         />
         <StyledTextInput
@@ -119,19 +123,26 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
             alignItems: 'center',
             marginTop: 20,
           }}>
-          {base64Image !== '' && (
-            <Image
-              style={{ width: 85, height: 85, borderRadius: 15, marginHorizontal: 20 }}
-              source={{ uri: base64Image }}
-            />
-          )}
+
           <View style={styles.button}>
             <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
           </View>
+          
           <View style={styles.button}>
             <StyledButton label="Save" onTap={() => onUpdate()} />
           </View>
+
         </View>
+
+        
+        <ImagePreview 
+          isModalVisible={imagePreviewVisible} 
+          setModalVisible={setImagePreviewVisible} 
+          b64Img={base64Image}
+          setb64img={setBase64Image}
+        />
+        
+
       </View>
     </CustomModal>
   );

--- a/client/src/modals/ItemSummary.jsx
+++ b/client/src/modals/ItemSummary.jsx
@@ -123,26 +123,21 @@ const ItemSummary = ({ modalVisible, setModalVisible, item, userCategories, type
             alignItems: 'center',
             marginTop: 20,
           }}>
-
           <View style={styles.button}>
             <StyledButton label="Cancel" onTap={() => setModalVisible(false)} />
           </View>
-          
+
           <View style={styles.button}>
             <StyledButton label="Save" onTap={() => onUpdate()} />
           </View>
-
         </View>
 
-        
-        <ImagePreview 
-          isModalVisible={imagePreviewVisible} 
-          setModalVisible={setImagePreviewVisible} 
+        <ImagePreview
+          isModalVisible={imagePreviewVisible}
+          setModalVisible={setImagePreviewVisible}
           b64Img={base64Image}
           setb64img={setBase64Image}
         />
-        
-
       </View>
     </CustomModal>
   );


### PR DESCRIPTION
## Description ✍️

Image preview modal appears after taking an image or if image already saved.

### Changes ⚙️

* Added a new modal component that opens up from the income/expense and item summary forms

![Screenshot_20220403-120007](https://user-images.githubusercontent.com/83952444/161443959-b231d698-97b7-4375-a374-17d7a3740c0e.jpg)



## Checklist 🗒

- [ ] Ran `black .` to format code in `./server`
- [x] Ran `npm run lint:fix` to format code in `./client`
- [ ] Assigned PR to all authors
- [x] Requested at least one reviewer
- [x] Linked the PR to its respective issue in ZenHub
- [x] Replaced the X below with the issue number

Closes #168 
